### PR TITLE
Feature: Process HubSpot meetings

### DIFF
--- a/Domain.js
+++ b/Domain.js
@@ -69,7 +69,11 @@ const DomainSchema = new Schema({
           deals: {
             type: Date,
             default: moment().subtract(4, 'year').toISOString()
-          }
+          },
+          meetings: {
+            type: Date,
+            default: moment().subtract(4, 'year').toISOString()
+          },
         }
       }]
     }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "HockeyStack",


### PR DESCRIPTION
Worker to process account meetings with contact.

## Processing the meetings

In general the the process to import the meetings is very similar with the `processContacts` with a few differences.
I created a `contacts` map to cache some contacts, after getting the meetings to contacts association I check all contacts Ids which aren't in the contacts map and batch fetch them using the `searchContacts`, exported from the `processContacts`, and store them in the contacts map for latter use and cache. It wasn't necessary to worry with the possibility to have pagination in this `searchContacts` in the worst scenario I'll have a 100 meetings with a 100 different contacts which fit in just one page.
Finally I process each meeting retrieving the contact `id` and `email` from the `contactAssociations` and sending them to the queue.

## Changes made

- Exported the objects search logic to a separate function to improve readability;
- Stopped the process immediately if no data was fetched;
- Refactored the pagination logic to check if has more pages to improve readability and simplicity;
- Started the pagination `offsetObject` with default values, there's no need to check if they are set latter and improve maintainability;
- In `processContacts` removed some unnecessary complexity fetching the contacts companies associations.

# Improvements to be made

- Create a folder struct to improve readability;
- Abstract all the HubSpot api into a class, specially the refresh access token logic;
- Abstract and reuse the pagination iteration logic, maybe transforming it into a async generator;
- Run all the process in parallel or in different scripts (Worry about HubSpot Api Rate Limit);
- Create Unit and integration tests.

* These considerations may change depending if this process are part of a bigger code base or if they run as a standalone script. 